### PR TITLE
Fix keyword parsing

### DIFF
--- a/SmugMugCore/SMEUploadRequest.m
+++ b/SmugMugCore/SMEUploadRequest.m
@@ -154,7 +154,7 @@ static void ReadStreamClientCallBack(CFReadStreamRef stream, CFStreamEventType t
 }
 
 -(NSString *)cleanKeywords:(NSArray *)theKeywords {
-	return [NSString stringWithFormat:@"\"%@\"", [theKeywords componentsJoinedByString:@"\" \""]];
+	return [NSString stringWithFormat:@"%@", [theKeywords componentsJoinedByString:@", "]];
 }
 
 -(void)beginUpload {


### PR DESCRIPTION
Some time ago, SmugMug move to using commas or semi-colons as a delimiter over spaces. And recently we removed support for space delimiting. This commit changes the keyword string from a quoted space delimited string into a comma delimited string.

eg. "keyword1, keyword2, keyword3"
