### PR TITLE
Set the image title on SmugMug with iPhoto's image title.

### DIFF
--- a/SmugMugCore/SMEUploadRequest.m
+++ b/SmugMugCore/SMEUploadRequest.m
@@ -184,6 +184,7 @@ static void ReadStreamClientCallBack(CFReadStreamRef stream, CFStreamEventType t
 	CFHTTPMessageSetHeaderFieldValue(myRequest, CFSTR("X-Smug-Version"), (CFStringRef)[self uploadApiVersion]);
 	CFHTTPMessageSetHeaderFieldValue(myRequest, CFSTR("X-Smug-ResponseType"), (CFStringRef)[self uploadResponseType]);	
 	CFHTTPMessageSetHeaderFieldValue(myRequest, CFSTR("X-Smug-FileName"), (CFStringRef)[self cleanNewlines:[[self image] title]]);
+	CFHTTPMessageSetHeaderFieldValue(myRequest, CFSTR("X-Smug-Title"), (CFStringRef)[self cleanNewlines:[[self image] title]]);
 	CFHTTPMessageSetHeaderFieldValue(myRequest, CFSTR("X-Smug-AlbumID"), (CFStringRef)[[self albumRef] albumId]);
 	
 	if(!IsEmpty([[self image] latitude]))


### PR DESCRIPTION
If the option 'Set the uploaded filename to the local image'  is set to 'title' then both the SmugMug filename and the SmugMug title will be set to the iPhoto's title.

If the option 'Set the uploaded filename to the local image'  is set to 'filename' then both the SmugMug filename and the SmugMug title will be set to the iPhoto's filename.
